### PR TITLE
update environment to fix issues with latest napari clusters plotter

### DIFF
--- a/conda_env_noGPU.yml
+++ b/conda_env_noGPU.yml
@@ -15,7 +15,6 @@ dependencies:
   - scikit-learn
   - tqdm
   - mrcfile
-  - cuml=23.12
   - cuda-version=11.8
   - git
   - hdbscan


### PR DESCRIPTION
add conda_env_noGPU with removed cuml dependency for mac users. and update conda_env to fix napari-clusters-plotter version to 0.8.1 due to _utilities.py requirement.

There is a known bug that if you click in the tomogram to locate a subvolume in the UMAP and then circle a cluster in the UMAP, you can't click back in the tomogram again. I'll have to look further into this. 